### PR TITLE
Update to include add_info method

### DIFF
--- a/{{cookiecutter.repo_name}}/rotest_{{cookiecutter.module_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/rotest_{{cookiecutter.module_name}}/__init__.py
@@ -75,9 +75,14 @@ class {{ cookiecutter.handler_class_name }}(AbstractResultHandler):
     def stop_test_run(self):
         """Called once after all tests are executed."""
 
-    def add_success(self, test, msg):
+    def add_success(self, test):
         """Called when a test has completed successfully.
+        Args:
+            test (rotest.core.abstract_test.AbstractTest): test item instance.
+        """
 
+    def add_info(self, test, msg):
+        """Called when a test registers a success message.
         Args:
             test (rotest.core.abstract_test.AbstractTest): test item instance.
             msg (str): success message.

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='{{ cookiecutter.repo_name }}',
-    version="0.1.0",
+    version="0.2.0",
     description="{{ cookiecutter.plugin_description }}",
     long_description=open("README.rst").read(),
     license="MIT",


### PR DESCRIPTION
Since Rotest 7.3.0
add_success doesn't have a message parameter
and a new method is introduced - add_info